### PR TITLE
[aws] installer: add option to wait for cluster ready

### DIFF
--- a/contrib/cmd/hypershift-aws/main.go
+++ b/contrib/cmd/hypershift-aws/main.go
@@ -25,6 +25,7 @@ func newHypershiftAWSCommand() *cobra.Command {
 func newInstallCommand() *cobra.Command {
 	releaseImage := ""
 	dhParamsFile := ""
+	waitForClusterReady := true
 	cmd := &cobra.Command{
 		Use:   "install NAME",
 		Short: "Creates the necessary infrastructure and installs a hypershift instance on an existing OCP 4 cluster running on AWS",
@@ -36,13 +37,14 @@ func newInstallCommand() *cobra.Command {
 			if len(name) == 0 {
 				log.Fatalf("You must specify the name of the cluster you want to install")
 			}
-			if err := aws.InstallCluster(name, releaseImage, dhParamsFile); err != nil {
+			if err := aws.InstallCluster(name, releaseImage, dhParamsFile, waitForClusterReady); err != nil {
 				log.WithError(err).Fatalf("Failed to install cluster")
 			}
 		},
 	}
 	cmd.Flags().StringVar(&releaseImage, "release-image", "", "[optional] Specify the release image to use for the new cluster. Defaults to same as parent cluster.")
 	cmd.Flags().StringVar(&dhParamsFile, "dh-params", "", "[optional][dev-only] Specifies an existing file with DH params for the VPN so it doesn't get re-generated.")
+	cmd.Flags().BoolVar(&waitForClusterReady, "wait-for-cluster-ready", waitForClusterReady, "Waits for cluster to be available before command ends, fails with an error if cluster does not come up within a given amount of time.")
 	return cmd
 }
 

--- a/contrib/pkg/aws/wait.go
+++ b/contrib/pkg/aws/wait.go
@@ -1,0 +1,161 @@
+package aws
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	clientwatch "k8s.io/client-go/tools/watch"
+
+	configapi "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+)
+
+const (
+	apiEndpointTimeout           = 10 * time.Minute
+	nodesReadyTimeout            = 10 * time.Minute
+	bootstrapPodCompleteTimeout  = 5 * time.Minute
+	clusterOperatorsReadyTimeout = 15 * time.Minute
+)
+
+func waitForAPIEndpoint(pkiDir, apiDNSName string) error {
+	caCertBytes, err := ioutil.ReadFile(filepath.Join(pkiDir, "root-ca.crt"))
+	if err != nil {
+		return fmt.Errorf("cannot read CA file: %v", err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCertBytes)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		},
+		Timeout: 3 * time.Second,
+	}
+
+	url := fmt.Sprintf("https://%s:6443/healthz", apiDNSName)
+
+	err = wait.PollImmediate(10*time.Second, apiEndpointTimeout, func() (bool, error) {
+		resp, err := client.Get(url)
+		if err != nil {
+			return false, nil
+		}
+		return resp.StatusCode == http.StatusOK, nil
+	})
+	return err
+}
+
+func waitForNodesReady(client kubeclient.Interface, expectedCount int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), nodesReadyTimeout)
+	defer cancel()
+	listWatcher := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), "nodes", "", fields.Everything())
+
+	allNodesReady := func(event watch.Event) (bool, error) {
+		list, err := listWatcher.List(metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("an error occurred listing nodes: %v", err)
+		}
+		nodeList, ok := list.(*corev1.NodeList)
+		if !ok {
+			return false, fmt.Errorf("unexpected object from list function: %t", list)
+		}
+		if len(nodeList.Items) < expectedCount {
+			return false, nil
+		}
+
+		for _, node := range nodeList.Items {
+			ready := false
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady {
+					if cond.Status == corev1.ConditionTrue {
+						ready = true
+						break
+					} else {
+						return false, nil
+					}
+				}
+			}
+			if !ready {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+	_, err := clientwatch.UntilWithSync(ctx, listWatcher, &corev1.Node{}, nil, allNodesReady)
+	return err
+}
+
+func waitForBootstrapPod(client kubeclient.Interface, namespace string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), bootstrapPodCompleteTimeout)
+	defer cancel()
+	listWatcher := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), "pods", "", fields.OneTermEqualSelector("metadata.name", "manifests-bootstrapper"))
+	podIsComplete := func(event watch.Event) (bool, error) {
+		pod, ok := event.Object.(*corev1.Pod)
+		if !ok {
+			return false, fmt.Errorf("unexpected object type")
+		}
+		if pod.Name != "manifests-bootstrapper" {
+			return false, fmt.Errorf("unexpected pod name: %s", pod.Name)
+		}
+		return pod.Status.Phase == corev1.PodSucceeded, nil
+	}
+	_, err := clientwatch.UntilWithSync(ctx, listWatcher, &corev1.Pod{}, nil, podIsComplete)
+	return err
+}
+
+func waitForClusterOperators(cfg *rest.Config) error {
+	client, err := configclient.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), clusterOperatorsReadyTimeout)
+	defer cancel()
+	listWatcher := cache.NewListWatchFromClient(client.RESTClient(), "clusteroperators", "", fields.Everything())
+
+	clusterOperatorsAreAvailable := func(event watch.Event) (bool, error) {
+		list, err := listWatcher.List(metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("an error occurred listing cluster operators: %v", err)
+		}
+		operatorList, ok := list.(*configapi.ClusterOperatorList)
+		if !ok {
+			return false, fmt.Errorf("unexpected object from list function: %t", list)
+		}
+
+		for _, co := range operatorList.Items {
+			available := false
+			for _, condition := range co.Status.Conditions {
+				if condition.Type == configapi.OperatorAvailable {
+					if condition.Status == configapi.ConditionTrue {
+						available = true
+						break
+					} else {
+						return false, nil
+					}
+				}
+			}
+			if !available {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+
+	_, err = clientwatch.UntilWithSync(ctx, listWatcher, &configapi.ClusterOperator{}, nil, clusterOperatorsAreAvailable)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/jteeuwen/go-bindata v0.0.0-00010101000000-000000000000
+	github.com/openshift/api v0.0.0-20190916204813-cdbe64fb0c91
+	github.com/openshift/client-go v0.0.0-20190813201236-5a5508328169
 	github.com/openshift/oc v0.0.0-00010101000000-000000000000
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2


### PR DESCRIPTION
Only affects aws contrib: Add option to not finish installer command until the target cluster is functional (needed to decide when to run e2e tests)