### PR TITLE
ca operator: fix looping when router-ca configmap is not present (Part 2)

### DIFF
--- a/assets/ca-operator/ca-operator-deployment.yaml
+++ b/assets/ca-operator/ca-operator-deployment.yaml
@@ -76,7 +76,6 @@ spec:
             if ! oc get cm -n openshift-config-managed router-ca -o jsonpath='{ .data.ca-bundle\.crt }' > /tmp/router.ca; then
                echo "Router ca is not available. It will not be included in the CA bundle"
                include_router_ca=0
-               continue
             fi
             if [[ include_router_ca == 1 ]]; then
               cat /etc/kubernetes/config/initial-ca.crt /tmp/router.ca /tmp/service.ca > /tmp/kcm.ca

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -293,7 +293,6 @@ spec:
             if ! oc get cm -n openshift-config-managed router-ca -o jsonpath='{ .data.ca-bundle\.crt }' > /tmp/router.ca; then
                echo "Router ca is not available. It will not be included in the CA bundle"
                include_router_ca=0
-               continue
             fi
             if [[ include_router_ca == 1 ]]; then
               cat /etc/kubernetes/config/initial-ca.crt /tmp/router.ca /tmp/service.ca > /tmp/kcm.ca


### PR DESCRIPTION
Missed removing `continue` when the configmap is not present