### PR TITLE
hack: improve portability of shell scripts

### DIFF
--- a/hack/update-generated-bindata.sh
+++ b/hack/update-generated-bindata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."

--- a/hack/verify-generated-bindata.sh
+++ b/hack/verify-generated-bindata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Not everyone has bash installed into /bin.