### PR TITLE
Change grant config from auto to deny

### DIFF
--- a/assets/oauth-openshift/oauth-server-config.yaml
+++ b/assets/oauth-openshift/oauth-server-config.yaml
@@ -23,7 +23,7 @@ oauthConfig:
   alwaysShowProviderSelection: false
   assetPublicURL: https://console-openshift-console.{{ .BaseDomain }}
   grantConfig:
-    method: deny
+    method: auto
     serviceAccountMethod: prompt
 {{ if .IdentityProviders }}  identityProviders:
 {{ trimTrailingSpace .IdentityProviders | indent 2 }}{{- else }}  identityProviders: []{{- end }}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2596,7 +2596,7 @@ oauthConfig:
   alwaysShowProviderSelection: false
   assetPublicURL: https://console-openshift-console.{{ .BaseDomain }}
   grantConfig:
-    method: deny
+    method: auto
     serviceAccountMethod: prompt
 {{ if .IdentityProviders }}  identityProviders:
 {{ trimTrailingSpace .IdentityProviders | indent 2 }}{{- else }}  identityProviders: []{{- end }}


### PR DESCRIPTION
Having grant config be deny will reject valid users unless they know to manually accept the grant options in the OIDC provider.