### PR TITLE
[4.3] Specify the AMI to use based on the region

### DIFF
--- a/contrib/pkg/aws/ami.go
+++ b/contrib/pkg/aws/ami.go
@@ -1,0 +1,21 @@
+package aws
+
+var AMIByRegion = map[string]string{
+	"ap-northeast-1": "ami-0bf6f5f209e5e041a",
+	"ap-northeast-2": "ami-03ae1c65102605f45",
+	"ap-south-1":     "ami-0cb6afbddc63fc2df",
+	"ap-southeast-1": "ami-0d506839070dc244b",
+	"ap-southeast-2": "ami-085848fd4435c94ec",
+	"ca-central-1":   "ami-01b36924502c16d0a",
+	"eu-central-1":   "ami-018420f426fa235e6",
+	"eu-north-1":     "ami-0d787e8fe2b42f20c",
+	"eu-west-1":      "ami-0123a5183598a0ac4",
+	"eu-west-2":      "ami-005192895e65f27d0",
+	"eu-west-3":      "ami-00a1b0be594a38046",
+	"me-south-1":     "ami-085f10932087a3c29",
+	"sa-east-1":      "ami-0f8a6a6d76d78708",
+	"us-east-1":      "ami-0c027d6d0a8882303",
+	"us-east-2":      "ami-0a8ba019bc9d4bd64",
+	"us-west-1":      "ami-03d44b77bad14081c",
+	"us-west-2":      "ami-0247e06438c49143e",
+}

--- a/contrib/pkg/aws/install.go
+++ b/contrib/pkg/aws/install.go
@@ -436,7 +436,7 @@ func InstallCluster(name, releaseImage, dhParamsFile string, waitForReady bool) 
 	}
 
 	// Create a machineset for the new cluster's worker nodes
-	if err = generateWorkerMachineset(dynamicClient, infraName, lbInfo.Zone, name, routerLBName, filepath.Join(manifestsDir, "machineset.json")); err != nil {
+	if err = generateWorkerMachineset(dynamicClient, region, infraName, lbInfo.Zone, name, routerLBName, filepath.Join(manifestsDir, "machineset.json")); err != nil {
 		return fmt.Errorf("failed to generate worker machineset: %v", err)
 	}
 	if err = generateUserDataSecret(name, bucketName, filepath.Join(manifestsDir, "machine-user-data.json")); err != nil {
@@ -903,7 +903,7 @@ func getNetworkInfo(client dynamic.Interface) (string, string, error) {
 	return serviceCIDR, podCIDR, nil
 }
 
-func generateWorkerMachineset(client dynamic.Interface, infraName, zone, namespace, lbName, fileName string) error {
+func generateWorkerMachineset(client dynamic.Interface, region, infraName, zone, namespace, lbName, fileName string) error {
 	machineGV, err := schema.ParseGroupVersion("machine.openshift.io/v1beta1")
 	if err != nil {
 		return err
@@ -929,6 +929,9 @@ func generateWorkerMachineset(client dynamic.Interface, infraName, zone, namespa
 	unstructured.SetNestedField(object, workerName, "metadata", "name")
 	unstructured.SetNestedField(object, workerName, "spec", "selector", "matchLabels", "machine.openshift.io/cluster-api-machineset")
 	unstructured.SetNestedField(object, workerName, "spec", "template", "metadata", "labels", "machine.openshift.io/cluster-api-machineset")
+	if ami, ok := AMIByRegion[region]; ok {
+		unstructured.SetNestedField(object, ami, "spec", "template", "spec", "providerSpec", "value", "ami", "id")
+	}
 	unstructured.SetNestedField(object, fmt.Sprintf("%s-user-data", namespace), "spec", "template", "spec", "providerSpec", "value", "userDataSecret", "name")
 	loadBalancer := map[string]interface{}{}
 	unstructured.SetNestedField(loadBalancer, lbName, "name")


### PR DESCRIPTION
[dev install] Use the ami from the installer code instead of just using the one from the host cluster.