### PR TITLE
[4.4] Render CVO manifests in bootstrapper

### DIFF
--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -27,6 +27,24 @@ spec:
       value: "true"
       effect: NoSchedule
   initContainers:
+    - image: {{ .ReleaseImage }}
+      imagePullPolicy: IfNotPresent
+      name: cluster-version-operator
+      workingDir: /tmp
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |-
+          cd /tmp
+          mkdir output
+          /usr/bin/cluster-version-operator render --output-dir /tmp/output --release-image {{ .ReleaseImage }}
+          # Exclude the CVO deployment manifest
+          rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
+          cp /tmp/output/manifests/* /work
+      volumeMounts:
+        - mountPath: /work
+          name: work
     - image: {{ imageFor "cluster-config-operator" }}
       imagePullPolicy: IfNotPresent
       name: config-operator

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -4213,6 +4213,24 @@ spec:
       value: "true"
       effect: NoSchedule
   initContainers:
+    - image: {{ .ReleaseImage }}
+      imagePullPolicy: IfNotPresent
+      name: cluster-version-operator
+      workingDir: /tmp
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |-
+          cd /tmp
+          mkdir output
+          /usr/bin/cluster-version-operator render --output-dir /tmp/output --release-image {{ .ReleaseImage }}
+          # Exclude the CVO deployment manifest
+          rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
+          cp /tmp/output/manifests/* /work
+      volumeMounts:
+        - mountPath: /work
+          name: work
     - image: {{ imageFor "cluster-config-operator" }}
       imagePullPolicy: IfNotPresent
       name: config-operator


### PR DESCRIPTION
In 4.4 CVO manifests are no longer applied by the CVO itself.
Adding an init container to the bootstrapper pod to render the CVO
manifests and apply them along with the other bootstrap manifests.