### PR TITLE
Add livez and readyz to liveness and readiness probes

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -57,14 +57,14 @@ spec:
           httpGet:
             scheme: HTTPS
             port: {{ .InternalAPIPort }}
-            path: healthz
+            path: livez
           initialDelaySeconds: 45
           timeoutSeconds: 10
         readinessProbe:
           httpGet:
             scheme: HTTPS
             port: {{ .InternalAPIPort }}
-            path: healthz
+            path: readyz
           initialDelaySeconds: 10
           timeoutSeconds: 10
 {{ if .KubeAPIServerResources }}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1827,14 +1827,14 @@ spec:
           httpGet:
             scheme: HTTPS
             port: {{ .InternalAPIPort }}
-            path: healthz
+            path: livez
           initialDelaySeconds: 45
           timeoutSeconds: 10
         readinessProbe:
           httpGet:
             scheme: HTTPS
             port: {{ .InternalAPIPort }}
-            path: healthz
+            path: readyz
           initialDelaySeconds: 10
           timeoutSeconds: 10
 {{ if .KubeAPIServerResources }}


### PR DESCRIPTION
Kubernetes recommends using [livez](https://github.com/kubernetes/kubernetes/pull/81969) and [readyz](https://github.com/kubernetes/kubernetes/pull/74416) for readiness and liveness probes for the apiserver because there are couple more checks added to these. For readyz, it uses the `minimal-shutdown-duration` that is set in the apiserver config for a "shutdown" flag. It helps make sure that when a apiserver pod that is shutting down doesn't receive any more requests because it's in a not ready state. For livez, it uses `maximum-startup-sequence-duration` to defer boot-sequence failures.

There is no downside to changing the healthz to readyz/livez, you get more HA, more checks than healthz that specifically designed for the apiserver, you can also see the checks to verify that readyz and livez have the same checks as healthz plus a couple more
```
$ curl $(kubectl config view | grep "server:" | head -1 | awk '{ print $2 }')/healthz\?verbose
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-discovery-available ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[+]poststarthook/rbac/bootstrap-roles ok
[+]poststarthook/scheduling/bootstrap-system-priority-classes ok
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/openshift.io-clientCA-reload ok
[+]poststarthook/openshift.io-requestheader-reload ok
[+]poststarthook/quota.openshift.io-clusterquotamapping ok
[+]poststarthook/openshift.io-kubernetes-informers-synched ok
[+]poststarthook/openshift.io-startkubeinformers ok
[+]poststarthook/aggregator-reload-proxy-client-cert ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/apiservice-wait-for-first-sync ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
healthz check passed
$ curl $(kubectl config view | grep "server:" | head -1 | awk '{ print $2 }')/livez\?verbose
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-discovery-available ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[+]poststarthook/rbac/bootstrap-roles ok
[+]poststarthook/scheduling/bootstrap-system-priority-classes ok
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/quota.openshift.io-clusterquotamapping ok
[+]poststarthook/openshift.io-kubernetes-informers-synched ok
[+]poststarthook/openshift.io-clientCA-reload ok
[+]poststarthook/openshift.io-requestheader-reload ok
[+]poststarthook/openshift.io-startkubeinformers ok
[+]poststarthook/aggregator-reload-proxy-client-cert ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/apiservice-wait-for-first-sync ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
healthz check passed
$ curl $(kubectl config view | grep "server:" | head -1 | awk '{ print $2 }')/readyz\?verbose
[+]ping ok
[+]log ok
[+]etcd ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/crd-discovery-available ok
[+]poststarthook/crd-informer-synced ok
[+]poststarthook/bootstrap-controller ok
[+]poststarthook/rbac/bootstrap-roles ok
[+]poststarthook/scheduling/bootstrap-system-priority-classes ok
[+]poststarthook/start-cluster-authentication-info-controller ok
[+]poststarthook/start-kube-apiserver-admission-initializer ok
[+]poststarthook/quota.openshift.io-clusterquotamapping ok
[+]poststarthook/openshift.io-kubernetes-informers-synched ok
[+]poststarthook/openshift.io-clientCA-reload ok
[+]poststarthook/openshift.io-requestheader-reload ok
[+]poststarthook/openshift.io-startkubeinformers ok
[+]poststarthook/aggregator-reload-proxy-client-cert ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/apiservice-wait-for-first-sync ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
[+]poststarthook/apiservice-openapi-controller ok
[+]shutdown ok
healthz check passed
```

