### PR TITLE
Default to a 1-pod etcd, remove artificial wait

### DIFF
--- a/assets/etcd/etcd-cluster.yaml
+++ b/assets/etcd/etcd-cluster.yaml
@@ -3,7 +3,7 @@ kind: EtcdCluster
 metadata:
   name: etcd
 spec:
-  size: 3
+  size: 1
   version: "3.2.13"
   TLS:
     static:

--- a/contrib/pkg/aws/install.go
+++ b/contrib/pkg/aws/install.go
@@ -467,13 +467,9 @@ func InstallCluster(name, releaseImage, dhParamsFile string, waitForReady bool) 
 	if err != nil {
 		return fmt.Errorf("failed to create a temporary directory for excluded manifests")
 	}
-	initialExclude := append(excludeManifests, "etcd-cluster.yaml")
-	if err = applyManifests(cfg, name, manifestsDir, initialExclude, excludedDir); err != nil {
+	log.Infof("Excluded manifests directory: %s", excludedDir)
+	if err = applyManifests(cfg, name, manifestsDir, excludeManifests, excludedDir); err != nil {
 		return fmt.Errorf("failed to apply manifests: %v", err)
-	}
-	time.Sleep(30 * time.Second)
-	if err = applyManifests(cfg, name, excludedDir, excludeManifests, manifestsDir); err != nil {
-		return fmt.Errorf("failed to apply etcd cluster manifest")
 	}
 	log.Infof("Cluster resources applied")
 

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -927,7 +927,7 @@ kind: EtcdCluster
 metadata:
   name: etcd
 spec:
-  size: 3
+  size: 1
   version: "3.2.13"
   TLS:
     static:


### PR DESCRIPTION
development only: A multi-node etcd cluster is still flaky on 4.4 clusters, defaulting to a 1-member cluster for development