### PR TITLE
Control plane operator fixes

### DIFF
--- a/pkg/controllers/autoapprover/reconciler.go
+++ b/pkg/controllers/autoapprover/reconciler.go
@@ -41,7 +41,7 @@ func (a *AutoApprover) approveCSR(csr *certsv1beta1.CertificateSigningRequest) e
 		Message:        "This CSR was automatically approved.",
 		LastUpdateTime: metav1.Now(),
 	})
-	_, err := a.KubeClient.CertificatesV1beta1().CertificateSigningRequests().Update(csr)
+	_, err := a.KubeClient.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(csr)
 	return err
 }
 

--- a/pkg/controllers/cmca/ca_updater.go
+++ b/pkg/controllers/cmca/ca_updater.go
@@ -100,6 +100,10 @@ func (r *ControllerManagerCAUpdater) Reconcile(req ctrl.Request) (ctrl.Result, e
 		return ctrl.Result{}, err
 	}
 	r.Log.Info("Updating controller manager deployment checksum annotation")
+
+	if cmDeployment.Spec.Template.ObjectMeta.Annotations == nil {
+		cmDeployment.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+	}
 	cmDeployment.Spec.Template.ObjectMeta.Annotations["ca-checksum"] = hash
 	if err = r.Update(ctx, cmDeployment); err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
Fix the following issues with control plane operator:
- [dev] auto approver is not using the right csr endpoint
- controller manager ca updater is failing when annotations in controller manager deployment template are nil.