### PR TITLE
Cluster version controller

### DIFF
--- a/cmd/control-plane-operator/main.go
+++ b/cmd/control-plane-operator/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hypershift-toolkit/pkg/cmd/cpoperator"
 	"github.com/openshift/hypershift-toolkit/pkg/controllers/autoapprover"
 	"github.com/openshift/hypershift-toolkit/pkg/controllers/clusteroperator"
+	"github.com/openshift/hypershift-toolkit/pkg/controllers/clusterversion"
 	"github.com/openshift/hypershift-toolkit/pkg/controllers/cmca"
 	"github.com/openshift/hypershift-toolkit/pkg/controllers/kubeadminpwd"
 )
@@ -37,6 +38,7 @@ var controllerFuncs = map[string]cpoperator.ControllerSetupFunc{
 	"cluster-operator":      clusteroperator.Setup,
 	"auto-approver":         autoapprover.Setup,
 	"kubeadmin-password":    kubeadminpwd.Setup,
+	"cluster-version":       clusterversion.Setup,
 }
 
 type ControlPlaneOperator struct {
@@ -90,6 +92,7 @@ func newControlPlaneOperator() *ControlPlaneOperator {
 		Controllers: []string{
 			"controller-manager-ca",
 			"cluster-operator",
+			"cluster-version",
 		},
 	}
 }

--- a/contrib/pkg/aws/install.go
+++ b/contrib/pkg/aws/install.go
@@ -392,6 +392,7 @@ func InstallCluster(name, releaseImage, dhParamsFile string, waitForReady bool) 
 		"auto-approver",
 		"kubeadmin-password",
 		"cluster-operator",
+		"cluster-version",
 	}
 	cpOperatorImage := os.Getenv("CONTROL_PLANE_OPERATOR_IMAGE_OVERRIDE")
 	if cpOperatorImage == "" {

--- a/pkg/controllers/clusterversion/reconcile.go
+++ b/pkg/controllers/clusterversion/reconcile.go
@@ -1,0 +1,47 @@
+package clusterversion
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	configlister "github.com/openshift/client-go/config/listers/config/v1"
+)
+
+const (
+	// NOTE: This needs to be set appropriately for the release associated with this code
+	DefaultChannel = "stable-4.4"
+)
+
+type ClusterVersionReconciler struct {
+	Client configclient.Interface
+	Lister configlister.ClusterVersionLister
+	Log    logr.Logger
+}
+
+func (r *ClusterVersionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	clusterVersion, err := r.Lister.Get(req.Name)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot fetch cluster version %s: %v", req.Name, err)
+	}
+	updateNeeded := false
+	// Always default to default channel
+	if clusterVersion.Spec.Channel != DefaultChannel {
+		clusterVersion.Spec.Channel = DefaultChannel
+		updateNeeded = true
+	}
+	// Remove any attempt at changing the clusterVersion
+	if clusterVersion.Spec.DesiredUpdate != nil {
+		clusterVersion.Spec.DesiredUpdate = nil
+		updateNeeded = true
+	}
+	if updateNeeded {
+		r.Log.Info("Updating clusterversion resource to desired values")
+		_, err := r.Client.ConfigV1().ClusterVersions().Update(clusterVersion)
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/clusterversion/setup.go
+++ b/pkg/controllers/clusterversion/setup.go
@@ -1,0 +1,40 @@
+package clusterversion
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+
+	"github.com/openshift/hypershift-toolkit/pkg/cmd/cpoperator"
+	"github.com/openshift/hypershift-toolkit/pkg/controllers"
+)
+
+func Setup(cfg *cpoperator.ControlPlaneOperatorConfig) error {
+	openshiftClient, err := configclient.NewForConfig(cfg.TargetConfig())
+	if err != nil {
+		return err
+	}
+	informerFactory := configinformers.NewSharedInformerFactory(openshiftClient, controllers.DefaultResync)
+	cfg.Manager().Add(manager.RunnableFunc(func(stopCh <-chan struct{}) error {
+		informerFactory.Start(stopCh)
+		return nil
+	}))
+	clusterVersions := informerFactory.Config().V1().ClusterVersions()
+	reconciler := &ClusterVersionReconciler{
+		Client: openshiftClient,
+		Lister: clusterVersions.Lister(),
+		Log:    cfg.Logger().WithName("ClusterVersion"),
+	}
+	c, err := controller.New("cluster-version", cfg.Manager(), controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return err
+	}
+	if err := c.Watch(&source.Informer{Informer: clusterVersions.Informer()}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This controller ensures that the channel for the ClusterVersion resource
remains fixed to a default value. It also ensures that desiredUpdate
remains nil. Any change done by the user via the console or the CLI will
be immediately reverted.