### PR TITLE
Controller to sync kubelet-serving-ca

### DIFF
--- a/Dockerfile.cpoperator
+++ b/Dockerfile.cpoperator
@@ -6,5 +6,6 @@ COPY . .
 RUN go build -mod=vendor -o ./bin/control-plane-operator ./cmd/control-plane-operator/main.go
 
 FROM registry.access.redhat.com/ubi7/ubi
+RUN yum -y update && yum clean all
 COPY --from=builder /go/src/github.com/openshift/hypershift-toolkit/bin/control-plane-operator /usr/bin/control-plane-operator
 ENTRYPOINT /usr/bin/control-plane-operator

--- a/cmd/control-plane-operator/main.go
+++ b/cmd/control-plane-operator/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hypershift-toolkit/pkg/controllers/clusterversion"
 	"github.com/openshift/hypershift-toolkit/pkg/controllers/cmca"
 	"github.com/openshift/hypershift-toolkit/pkg/controllers/kubeadminpwd"
+	"github.com/openshift/hypershift-toolkit/pkg/controllers/kubelet_serving_ca"
 )
 
 const (
@@ -39,6 +40,7 @@ var controllerFuncs = map[string]cpoperator.ControllerSetupFunc{
 	"auto-approver":         autoapprover.Setup,
 	"kubeadmin-password":    kubeadminpwd.Setup,
 	"cluster-version":       clusterversion.Setup,
+	"kubelet-serving-ca":    kubelet_serving_ca.Setup,
 }
 
 type ControlPlaneOperator struct {
@@ -93,6 +95,7 @@ func newControlPlaneOperator() *ControlPlaneOperator {
 			"controller-manager-ca",
 			"cluster-operator",
 			"cluster-version",
+			"kubelet-serving-ca",
 		},
 	}
 }

--- a/pkg/controllers/kubelet_serving_ca/setup.go
+++ b/pkg/controllers/kubelet_serving_ca/setup.go
@@ -1,0 +1,32 @@
+package kubelet_serving_ca
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift/hypershift-toolkit/pkg/cmd/cpoperator"
+	"github.com/openshift/hypershift-toolkit/pkg/controllers"
+)
+
+const (
+	ControlPlaneOperatorConfig = "control-plane-operator"
+)
+
+func Setup(cfg *cpoperator.ControlPlaneOperatorConfig) error {
+
+	reconciler := &KubeletServingCASyncer{
+		Client:       cfg.Manager().GetClient(),
+		Namespace:    cfg.Namespace(),
+		TargetClient: cfg.TargetKubeClient(),
+		Log:          cfg.Logger().WithName("KubeletServingCA"),
+	}
+	c, err := controller.New("kubelet-serving-ca", cfg.Manager(), controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return err
+	}
+	if err := c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, controllers.NamedResourceHandler(ControlPlaneOperatorConfig)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/controllers/kubelet_serving_ca/syncer.go
+++ b/pkg/controllers/kubelet_serving_ca/syncer.go
@@ -1,0 +1,72 @@
+package kubelet_serving_ca
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// syncInterval is the amount of time to use between checks
+var syncInterval = 5 * time.Minute
+
+type KubeletServingCASyncer struct {
+	client.Client
+	Namespace    string
+	TargetClient kubeclient.Interface
+	Log          logr.Logger
+}
+
+func (s *KubeletServingCASyncer) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	if req.Namespace != s.Namespace {
+		return result(nil)
+	}
+	if req.Name != ControlPlaneOperatorConfig {
+		return result(nil)
+	}
+	cpConfig := &corev1.ConfigMap{}
+	if err := s.Get(ctx, req.NamespacedName, cpConfig); err != nil {
+		return ctrl.Result{}, err
+	}
+	targetConfigMap, err := s.TargetClient.CoreV1().ConfigMaps("openshift-config-managed").Get("kubelet-serving-ca", metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return result(err)
+	}
+	expectedConfigMap := s.expectedConfigMap(cpConfig)
+	if err != nil {
+		s.Log.Info("target configmap not found, creating it")
+		_, err = s.TargetClient.CoreV1().ConfigMaps("openshift-config-managed").Create(expectedConfigMap)
+		return result(err)
+	}
+	if targetConfigMap.Data["ca-bundle.crt"] != expectedConfigMap.Data["ca-bundle.crt"] {
+		targetConfigMap.Data["ca-bundle.crt"] = expectedConfigMap.Data["ca-bundle.crt"]
+		_, err = s.TargetClient.CoreV1().ConfigMaps("openshift-config-managed").Update(targetConfigMap)
+		return result(err)
+	}
+	return result(nil)
+}
+
+func result(err error) (ctrl.Result, error) {
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: syncInterval}, nil
+}
+
+func (s *KubeletServingCASyncer) expectedConfigMap(source *corev1.ConfigMap) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{}
+	cm.Name = "kubelet-serving-ca"
+	cm.Namespace = "openshift-config-managed"
+	cm.Data = map[string]string{
+		"ca-bundle.crt": source.Data["initial-ca.crt"],
+	}
+	return cm
+}


### PR DESCRIPTION
Adds a simple controller to create (and update) the `kubelet-serving-ca` configmap in `openshift-config-managed`
Adds `yum -y update all` to Dockerfile for control plane operator