### PR TITLE
Bug 1966477 deprecated ApiVersion on Audit Policy

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -54,7 +54,7 @@ auditConfig:
   webHookMode: batch
 {{ else }}
   policyConfiguration:
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: audit.k8s.io/v1
     kind: Policy
     omitStages:
     - RequestReceived

--- a/assets/openshift-apiserver/config.yaml
+++ b/assets/openshift-apiserver/config.yaml
@@ -22,7 +22,7 @@ auditConfig:
   maximumFileSizeMegabytes: 100
   maximumRetainedFiles: 10
   policyConfiguration:
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: audit.k8s.io/v1
     kind: Policy
     omitStages:
     - RequestReceived

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1470,7 +1470,7 @@ auditConfig:
   webHookMode: batch
 {{ else }}
   policyConfiguration:
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: audit.k8s.io/v1
     kind: Policy
     omitStages:
     - RequestReceived
@@ -2887,7 +2887,7 @@ auditConfig:
   maximumFileSizeMegabytes: 100
   maximumRetainedFiles: 10
   policyConfiguration:
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: audit.k8s.io/v1
     kind: Policy
     omitStages:
     - RequestReceived


### PR DESCRIPTION
The v1beta1 version for audit is outdated as of k8s 1.12
This older version reference within this repo is triggers a warning in pod logs due to deprecation warning added in upstream here: https://github.com/kubernetes/kubernetes/pull/98858
This PR updates to v1 to stop warnings